### PR TITLE
Fix chunk counter displaying incorrect position in modal

### DIFF
--- a/config/react-frontend/src/components/Document/DocumentViewer.jsx
+++ b/config/react-frontend/src/components/Document/DocumentViewer.jsx
@@ -621,7 +621,7 @@ const DocumentViewer = () => {
             chunk={selectedChunk}
             document={selectedDocument}
             chunkIndex={chunkIndex}
-            totalChunks={chunks.length > 0 ? Math.max(...chunks.map(c => c.index !== undefined ? c.index : -1)) + 1 : 0}
+            totalChunks={chunks.length}
             onClose={() => setSelectedChunk(null)}
             onNavigate={handleChunkNavigate}
           />


### PR DESCRIPTION
Fixes #11

## Summary
- Fixed chunk navigation modal showing "1 of 1" instead of actual chunk position
- Replaced complex totalChunks calculation with simple `chunks.length`
- Confirmed with automated test that detected the bug

## Changes
- Updated `DocumentViewer.jsx:624` to use `chunks.length` for totalChunks prop
- Removed unnecessary complex calculation: `Math.max(...chunks.map(c => c.index \!== undefined ? c.index : -1)) + 1`

## Test Results
Before fix: "1 of 1" displayed
After fix: Shows actual chunk count (e.g., "177" chunks)

## Test Plan
- [ ] Verify chunk modal shows correct position numbers
- [ ] Test navigation between chunks updates position correctly
- [ ] Confirm no regressions in chunk inspector functionality

🤖 Generated with [Claude Code](https://claude.ai/code)